### PR TITLE
Removed && let statements to guarantee more backward compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/p12-keystore"
 readme = "README.md"
 keywords = ["pkcs12", "pfx", "keystore", "truststore"]
 edition = "2024"
+rust-version = "1.85"
 
 [features]
 default = ["pbes1"]
@@ -21,7 +22,10 @@ pkcs12 = { version = "0.2.0-pre.0", features = ["kdf"] }
 cms = "0.3.0-pre.1"
 der = { version = "0.8.0-rc.10", features = ["std", "derive"] }
 thiserror = "2"
-cbc = { version = "0.2.0-rc.2", features = ["block-padding", "alloc"], optional = true }
+cbc = { version = "0.2.0-rc.2", features = [
+    "block-padding",
+    "alloc",
+], optional = true }
 rc2 = { version = "0.9.0-rc.0", optional = true }
 des = { version = "0.9.0-rc.2", optional = true }
 sha1 = "0.11.0-rc.4"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -277,15 +277,15 @@ fn parse_bags(bags: SafeContents, password: &str) -> Result<ParsedAuthSafe> {
             oid::PKCS_12_SECRET_BAG_OID => {
                 let secret_bag = SecretBag::from_bag_der(&bag.bag_value)?;
 
-                if let Ok(priv_key) = secret_bag.private_key_info(password)
-                    && let Some(local_key_id) = local_key_id
-                {
-                    let key = Secret {
-                        key_type: SecretKeyType::from_oid(&priv_key.algorithm.oid),
-                        key: priv_key.private_key.into_bytes().into(),
-                        local_key_id: local_key_id.into(),
-                    };
-                    secrets.push(ParsedSecret { friendly_name, key });
+                if let Ok(priv_key) = secret_bag.private_key_info(password) {
+                    if let Some(local_key_id) = local_key_id {
+                        let key = Secret {
+                            key_type: SecretKeyType::from_oid(&priv_key.algorithm.oid),
+                            key: priv_key.private_key.into_bytes().into(),
+                            local_key_id: local_key_id.into(),
+                        };
+                        secrets.push(ParsedSecret { friendly_name, key });
+                    }
                 }
             }
             _ => {}
@@ -354,14 +354,16 @@ impl SecretBag {
     pub fn private_key_info(&self, password: &str) -> Result<PrivateKeyInfo> {
         if let Ok(enc_key) =
             pkcs12::pbe_params::EncryptedPrivateKeyInfo::from_der(self.encrypted_private_key_info.as_bytes())
-            && let Ok(plain) = decrypt(
+        {
+            if let Ok(plain) = decrypt(
                 &enc_key.encryption_algorithm,
                 enc_key.encrypted_data.as_bytes(),
                 password,
-            )
-            && let Ok(priv_key) = PrivateKeyInfo::from_der(&plain)
-        {
-            return Ok(priv_key);
+            ) {
+                if let Ok(priv_key) = PrivateKeyInfo::from_der(&plain) {
+                    return Ok(priv_key);
+                }
+            }
         }
         Err(Error::UnsupportedEncryptionScheme)
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -236,7 +236,7 @@ fn parse_bags(bags: SafeContents, password: &str) -> Result<ParsedAuthSafe> {
                 if let Some(local_key_id) = local_key_id {
                     let key = PrivateKey::from_der(&cs.value.to_der()?)?;
                     let key = PrivateKeyChain {
-                        key: key,
+                        key,
                         local_key_id: local_key_id.into(),
                         certs: vec![],
                     };

--- a/tests/test_import_policies.rs
+++ b/tests/test_import_policies.rs
@@ -32,14 +32,11 @@ fn test_relaxed_policy() {
 
     // Keys with matching certificates should have cert chains
     // Keys without matching certificates should have empty cert chains
-    let mut has_empty_chain = false;
     let mut has_full_chain = false;
 
     for (_, entry) in keystore.entries() {
         if let KeyStoreEntry::PrivateKeyChain(chain) = entry {
-            if chain.certs().is_empty() {
-                has_empty_chain = true;
-            } else {
+            if !chain.certs().is_empty() {
                 has_full_chain = true;
             }
         }


### PR DESCRIPTION
This PR removes 3 &&let statements that are incompatible with a current Rust toolchain version we use < 1.88

The let chains feature stabilization and syntax requirements have evolved across Rust versions, and these particular patterns were causing compilation errors. As the feature is less than a year old, and not spread accross the codebase I gave it a try.

The logic has been refactored to maintain the same behavior while using patterns compatible with our toolchain.

It decreases the msrv from 1.88 to 1.85.1